### PR TITLE
Clean ups

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@
 venv
 *.iml
 .vscode
+/.idea/

--- a/README.md
+++ b/README.md
@@ -76,7 +76,7 @@ POST
 }
 ```
 
-`timestamp`: Unix timestamp, e.g. `1504777098`   
+`timestamp`: Unix timestamp (the number of seconds since 1 January 1970 00:00:00 UTC, minus leap seconds), e.g. `1504777098`   
 `reading`: kW reading of smart meter at that time, e.g. `0.0503`
 
 ### Get Stored Readings

--- a/src/app_initializer.py
+++ b/src/app_initializer.py
@@ -16,7 +16,7 @@ NUM_READINGS_AGAINST_METER = 5
 
 def populate_random_electricity_readings():
     for index in range(NUM_METERS):
-        smartMeterId = f"meter-{index}"
+        smartMeterId = f"smart-meter-{index}"
         electricity_reading_service.store_reading({
             "smartMeterId": smartMeterId,
             "electricityReadings": generate_electricity_readings(NUM_READINGS_AGAINST_METER)

--- a/src/generator/electricity_reading_generator.py
+++ b/src/generator/electricity_reading_generator.py
@@ -1,4 +1,3 @@
-from datetime import datetime
 from service.time_converter import TimeConverter
 
 import math

--- a/src/generator/electricity_reading_generator.py
+++ b/src/generator/electricity_reading_generator.py
@@ -1,16 +1,18 @@
-from service.time_converter import TimeConverter
+from service.time_converter import iso_format_to_unix_time
 
 import math
 import random
 
+
 def random_int_between(min_val, max_val):
     return "%02d" % random.randrange(min_val, max_val)
+
 
 def generate_electricity_readings(num):
     readings = []
     for i in range(num):
         random_time = f"2001-{random_int_between(1,12)}-{random_int_between(1,28)}T{random_int_between(0,23)}:{random_int_between(0,59)}:{random_int_between(0,59)}"
         random_reading = math.floor(random.random() * 1000)/1000
-        readings.append({"time": TimeConverter.iso_format_to_unix_time(random_time), "reading": random_reading})
+        readings.append({"time": iso_format_to_unix_time(random_time), "reading": random_reading})
 
     return readings

--- a/src/generator/electricity_reading_generator.py
+++ b/src/generator/electricity_reading_generator.py
@@ -1,18 +1,17 @@
 from datetime import datetime
+from service.time_converter import TimeConverter
+
 import math
 import random
 
 def random_int_between(min_val, max_val):
     return "%02d" % random.randrange(min_val, max_val)
 
-def unix_time_of(dt):
-    return (dt - datetime(1970, 1, 1)).total_seconds()
-
 def generate_electricity_readings(num):
     readings = []
     for i in range(num):
-        random_time = datetime.fromisoformat(f"2001-{random_int_between(1,12)}-{random_int_between(1,28)}T{random_int_between(0,23)}:{random_int_between(0,59)}:{random_int_between(0,59)}")
+        random_time = f"2001-{random_int_between(1,12)}-{random_int_between(1,28)}T{random_int_between(0,23)}:{random_int_between(0,59)}:{random_int_between(0,59)}"
         random_reading = math.floor(random.random() * 1000)/1000
-        readings.append({"time": unix_time_of(random_time), "reading": random_reading})
+        readings.append({"time": TimeConverter.iso_format_to_unix_time(random_time), "reading": random_reading})
 
     return readings

--- a/src/service/account_service.py
+++ b/src/service/account_service.py
@@ -1,10 +1,10 @@
 class AccountService:
     plan_ids_by_meter = {
-        "meter-0": "price-plan-0",
-        "meter-1": "price-plan-1",
-        "meter-2": "price-plan-0",
-        "meter-3": "price-plan-2",
-        "meter-4": "price-plan-1",
+        "smart-meter-0": "price-plan-0",
+        "smart-meter-1": "price-plan-1",
+        "smart-meter-2": "price-plan-0",
+        "smart-meter-3": "price-plan-2",
+        "smart-meter-4": "price-plan-1",
     }
 
     def get_price_plan(self, smart_meter_id):

--- a/src/service/price_plan_service.py
+++ b/src/service/price_plan_service.py
@@ -3,7 +3,13 @@ from functools import reduce
 from repository.price_plan_repository import price_plan_repository
 
 from .electricity_reading_service import ElectricityReadingService
-from .time_converter import TimeConverter
+from .time_converter import time_elapsed_in_hours
+
+
+def calculate_time_elapsed(readings):
+    min_time = min(map(lambda r: r.time, readings))
+    max_time = max(map(lambda r: r.time, readings))
+    return time_elapsed_in_hours(min_time, max_time)
 
 
 class PricePlanService:
@@ -16,10 +22,11 @@ class PricePlanService:
             return []
 
         average = self.calculate_average_reading(readings)
-        time_elapsed = self.calculate_time_elapsed(readings)
+        time_elapsed = calculate_time_elapsed(readings)
         consumed_energy = average / time_elapsed
 
         price_plans = price_plan_repository.get()
+
         def cost_from_plan(price_plan):
             cost = {}
             cost[price_plan.name] = consumed_energy * price_plan.unit_rate
@@ -32,8 +39,3 @@ class PricePlanService:
     def calculate_average_reading(self, readings):
         sum = reduce((lambda p, c: p + c), map(lambda r: r.reading, readings), 0)
         return sum / len(readings)
-
-    def calculate_time_elapsed(self, readings):
-        min_time = min(map(lambda r: r.time, readings))
-        max_time = max(map(lambda r: r.time, readings))
-        return TimeConverter.time_elapsed_in_hours(min_time, max_time)

--- a/src/service/time_converter.py
+++ b/src/service/time_converter.py
@@ -1,14 +1,13 @@
 from datetime import datetime
 
-class TimeConverter:
-    @staticmethod
-    def iso_format_to_unix_time(iso_format_string):
-        return TimeConverter.__unix_time_of(datetime.fromisoformat(iso_format_string))
 
-    @staticmethod
-    def __unix_time_of(dt):
-        return int((dt - datetime(1970,1,1)).total_seconds())
+def iso_format_to_unix_time(iso_format_string):
+    return __unix_time_of(datetime.fromisoformat(iso_format_string))
 
-    @staticmethod
-    def time_elapsed_in_hours(earliest_unix_timestamp, latest_unix_timestamp):
-        return (latest_unix_timestamp - earliest_unix_timestamp) / 3600
+
+def __unix_time_of(dt):
+    return int((dt - datetime(1970, 1, 1)).total_seconds())
+
+
+def time_elapsed_in_hours(earliest_unix_timestamp, latest_unix_timestamp):
+    return (latest_unix_timestamp - earliest_unix_timestamp) / 3600

--- a/src/service/time_converter.py
+++ b/src/service/time_converter.py
@@ -2,5 +2,13 @@ from datetime import datetime
 
 class TimeConverter:
     @staticmethod
+    def iso_format_to_unix_time(iso_format_string):
+        return TimeConverter.__unix_time_of(datetime.fromisoformat(iso_format_string))
+
+    @staticmethod
+    def __unix_time_of(dt):
+        return int((dt - datetime(1970,1,1)).total_seconds())
+
+    @staticmethod
     def time_elapsed_in_hours(earliest_unix_timestamp, latest_unix_timestamp):
         return (latest_unix_timestamp - earliest_unix_timestamp) / 3600

--- a/test/controller/test_electricityReadingController.py
+++ b/test/controller/test_electricityReadingController.py
@@ -2,7 +2,7 @@ import unittest
 
 from .setup_test_app import app
 
-class MyTestCase(unittest.TestCase):
+class TestElectricityReadingController(unittest.TestCase):
     def setUp(self):
         self.client = app.test_client()
 

--- a/test/controller/test_pricePlanComparatorController.py
+++ b/test/controller/test_pricePlanComparatorController.py
@@ -25,7 +25,7 @@ class TestPricePlanComparatorController(unittest.TestCase):
     def test_recommend_cheapest_price_plans_no_limit_for_meter_usage(self):
         readings = [
             { "time": TimeConverter.iso_format_to_unix_time('2020-01-05T10:30:00'), "reading": 35.0 },
-            { "time": TimeConverter.iso_format_to_unix_time('2020-01-05T11:00:00'), "reading": 3.0 }
+            { "time": TimeConverter.iso_format_to_unix_time('2020-01-05T11:00:00'), "reading": 5.0 }
         ]
 
         readingJson = {
@@ -37,7 +37,7 @@ class TestPricePlanComparatorController(unittest.TestCase):
         res = self.client.get('/price-plans/recommend/meter-103')
         self.assertEqual(res.status_code, 200)
         self.assertEqual(res.get_json(), [
-            { "price-plan-2": 38 },
-            { "price-plan-1": 76 },
-            { "price-plan-0": 380 }
+            { "price-plan-2": 40 },
+            { "price-plan-1": 80 },
+            { "price-plan-0": 400 }
         ])

--- a/test/controller/test_pricePlanComparatorController.py
+++ b/test/controller/test_pricePlanComparatorController.py
@@ -3,9 +3,10 @@ import unittest
 from repository.price_plan_repository import price_plan_repository
 from controller.electricity_reading_controller import repository as readings_repository
 from app_initializer import initialize_data
-from service.time_converter import TimeConverter
+from service.time_converter import iso_format_to_unix_time
 
 from .setup_test_app import app
+
 
 class TestPricePlanComparatorController(unittest.TestCase):
     def setUp(self):
@@ -24,8 +25,8 @@ class TestPricePlanComparatorController(unittest.TestCase):
 
     def test_recommend_cheapest_price_plans_no_limit_for_meter_usage(self):
         readings = [
-            { "time": TimeConverter.iso_format_to_unix_time('2020-01-05T10:30:00'), "reading": 35.0 },
-            { "time": TimeConverter.iso_format_to_unix_time('2020-01-05T11:00:00'), "reading": 5.0 }
+            { "time": iso_format_to_unix_time('2020-01-05T10:30:00'), "reading": 35.0 },
+            { "time": iso_format_to_unix_time('2020-01-05T11:00:00'), "reading": 5.0 }
         ]
 
         readingJson = {

--- a/test/controller/test_pricePlanComparatorController.py
+++ b/test/controller/test_pricePlanComparatorController.py
@@ -17,7 +17,7 @@ class TestPricePlanComparatorController(unittest.TestCase):
         readings_repository.clear()
 
     def test_get_costs_against_all_price_plans(self):
-        res = self.client.get('/price-plans/compare-all/meter-1')
+        res = self.client.get('/price-plans/compare-all/smart-meter-1')
         self.assertEqual(res.status_code, 200)
         self.assertEqual(res.get_json()['pricePlanId'], 'price-plan-1')
         self.assertEqual(len(res.get_json()['pricePlanComparisons']), 3)

--- a/test/controller/test_pricePlanComparatorController.py
+++ b/test/controller/test_pricePlanComparatorController.py
@@ -1,9 +1,9 @@
-from datetime import datetime
 import unittest
 
 from repository.price_plan_repository import price_plan_repository
 from controller.electricity_reading_controller import repository as readings_repository
 from app_initializer import initialize_data
+from service.time_converter import TimeConverter
 
 from .setup_test_app import app
 
@@ -24,8 +24,8 @@ class TestPricePlanComparatorController(unittest.TestCase):
 
     def test_recommend_cheapest_price_plans_no_limit_for_meter_usage(self):
         readings = [
-            { "time": self.unix_time_of('2020-01-05T10:30:00'), "reading": 35.0 },
-            { "time": self.unix_time_of('2020-01-05T11:00:00'), "reading": 3.0 }
+            { "time": TimeConverter.iso_format_to_unix_time('2020-01-05T10:30:00'), "reading": 35.0 },
+            { "time": TimeConverter.iso_format_to_unix_time('2020-01-05T11:00:00'), "reading": 3.0 }
         ]
 
         readingJson = {
@@ -41,7 +41,3 @@ class TestPricePlanComparatorController(unittest.TestCase):
             { "price-plan-1": 76 },
             { "price-plan-0": 380 }
         ])
-
-    def unix_time_of(self, iso_date):
-        dt = datetime.fromisoformat(iso_date)
-        return int((dt - datetime(1970,1,1)).total_seconds())

--- a/test/service/test_ElectricityReadingService.py
+++ b/test/service/test_ElectricityReadingService.py
@@ -1,10 +1,10 @@
-from datetime import datetime
 from unittest import TestCase
 from unittest.mock import MagicMock
 
 from domain.electricity_reading import ElectricityReading
 from repository.electricity_reading_repository import ElectricityReadingRepository
 from service.electricity_reading_service import ElectricityReadingService
+from service.time_converter import TimeConverter
 
 
 class TestElectricityReadingService(TestCase):
@@ -17,8 +17,8 @@ class TestElectricityReadingService(TestCase):
         json = {
             "smartMeterId": "meter-45",
             "electricityReadings": [
-                {"time": datetime.strptime('2015-03-02T08:55:00', '%Y-%m-%dT%H:%M:%S').timestamp(), "reading": 0.812},
-                {"time": datetime.strptime('2015-09-02T08:55:00', '%Y-%m-%dT%H:%M:%S').timestamp(), "reading": 0.23}
+                {"time": TimeConverter.iso_format_to_unix_time('2015-03-02T08:55:00'), "reading": 0.812},
+                {"time": TimeConverter.iso_format_to_unix_time('2015-09-02T08:55:00'), "reading": 0.23}
             ]
         }
 
@@ -26,7 +26,7 @@ class TestElectricityReadingService(TestCase):
 
         self.repository.store.assert_called_with('meter-45', [
             ElectricityReading(
-                {"time": datetime.strptime('2015-03-02T08:55:00', '%Y-%m-%dT%H:%M:%S').timestamp(), "reading": 0.812}),
+                {"time": TimeConverter.iso_format_to_unix_time('2015-03-02T08:55:00'), "reading": 0.812}),
             ElectricityReading(
-                {"time": datetime.strptime('2015-09-02T08:55:00', '%Y-%m-%dT%H:%M:%S').timestamp(), "reading": 0.23})
+                {"time": TimeConverter.iso_format_to_unix_time('2015-09-02T08:55:00'), "reading": 0.23})
         ])

--- a/test/service/test_ElectricityReadingService.py
+++ b/test/service/test_ElectricityReadingService.py
@@ -4,7 +4,7 @@ from unittest.mock import MagicMock
 from domain.electricity_reading import ElectricityReading
 from repository.electricity_reading_repository import ElectricityReadingRepository
 from service.electricity_reading_service import ElectricityReadingService
-from service.time_converter import TimeConverter
+from service.time_converter import iso_format_to_unix_time
 
 
 class TestElectricityReadingService(TestCase):
@@ -17,8 +17,8 @@ class TestElectricityReadingService(TestCase):
         json = {
             "smartMeterId": "meter-45",
             "electricityReadings": [
-                {"time": TimeConverter.iso_format_to_unix_time('2015-03-02T08:55:00'), "reading": 0.812},
-                {"time": TimeConverter.iso_format_to_unix_time('2015-09-02T08:55:00'), "reading": 0.23}
+                {"time": iso_format_to_unix_time('2015-03-02T08:55:00'), "reading": 0.812},
+                {"time": iso_format_to_unix_time('2015-09-02T08:55:00'), "reading": 0.23}
             ]
         }
 
@@ -26,7 +26,7 @@ class TestElectricityReadingService(TestCase):
 
         self.repository.store.assert_called_with('meter-45', [
             ElectricityReading(
-                {"time": TimeConverter.iso_format_to_unix_time('2015-03-02T08:55:00'), "reading": 0.812}),
+                {"time": iso_format_to_unix_time('2015-03-02T08:55:00'), "reading": 0.812}),
             ElectricityReading(
-                {"time": TimeConverter.iso_format_to_unix_time('2015-09-02T08:55:00'), "reading": 0.23})
+                {"time": iso_format_to_unix_time('2015-09-02T08:55:00'), "reading": 0.23})
         ])

--- a/test/service/test_PricePlanService.py
+++ b/test/service/test_PricePlanService.py
@@ -6,7 +6,8 @@ from domain.price_plan import PricePlan
 from repository.electricity_reading_repository import ElectricityReadingRepository
 from repository.price_plan_repository import price_plan_repository
 from service.price_plan_service import PricePlanService
-from service.time_converter import TimeConverter
+from service.time_converter import iso_format_to_unix_time
+
 
 class TestPricePlanService(TestCase):
     electricity_reading_repository = ElectricityReadingRepository()
@@ -17,17 +18,17 @@ class TestPricePlanService(TestCase):
 
     def test_calculate_costs_against_all_price_plans(self):
         price_plan_repository.store([PricePlan('X1', 'XS1', 10, []),
-            PricePlan('X2', 'XS2', 2, []),
-            PricePlan('X6', 'XS6', 1, [])])
+                                     PricePlan('X2', 'XS2', 2, []),
+                                     PricePlan('X6', 'XS6', 1, [])])
 
         reading_service_mock = MagicMock(return_value=[
-            ElectricityReading({ "time": TimeConverter.iso_format_to_unix_time('2017-11-10T09:00:00'), "reading": 0.65 }),
-            ElectricityReading({ "time": TimeConverter.iso_format_to_unix_time('2017-11-10T09:30:00'), "reading": 0.35 }),
-            ElectricityReading({ "time": TimeConverter.iso_format_to_unix_time('2017-11-10T10:00:00'), "reading": 0.5 })
+            ElectricityReading({"time": iso_format_to_unix_time('2017-11-10T09:00:00'), "reading": 0.65}),
+            ElectricityReading({"time": iso_format_to_unix_time('2017-11-10T09:30:00'), "reading": 0.35}),
+            ElectricityReading({"time": iso_format_to_unix_time('2017-11-10T10:00:00'), "reading": 0.5})
         ])
         self.price_plan_service.electricity_reading_service.retrieve_readings_for = reading_service_mock
 
         spend = self.price_plan_service.get_list_of_spend_against_each_price_plan_for('smart-meter-1001')
-        self.assertEqual(spend[0], { 'X6': 0.5 })
-        self.assertEqual(spend[1], { 'X2': 1 })
-        self.assertEqual(spend[2], { 'X1': 5 })
+        self.assertEqual(spend[0], {'X6': 0.5})
+        self.assertEqual(spend[1], {'X2': 1})
+        self.assertEqual(spend[2], {'X1': 5})

--- a/test/service/test_PricePlanService.py
+++ b/test/service/test_PricePlanService.py
@@ -6,6 +6,7 @@ from domain.price_plan import PricePlan
 from repository.electricity_reading_repository import ElectricityReadingRepository
 from repository.price_plan_repository import price_plan_repository
 from service.price_plan_service import PricePlanService
+from service.time_converter import TimeConverter
 
 class TestPricePlanService(TestCase):
     electricity_reading_repository = ElectricityReadingRepository()
@@ -20,13 +21,13 @@ class TestPricePlanService(TestCase):
             PricePlan('X6', 'XS6', 1, [])])
 
         reading_service_mock = MagicMock(return_value=[
-            ElectricityReading({ "time": 1510307115, "reading": 0.5778640126312636 }),
-            ElectricityReading({ "time": 1510307125, "reading": 0.19979840426464207 }),
-            ElectricityReading({ "time": 1510307135, "reading": 0.22644598149484024 })
+            ElectricityReading({ "time": TimeConverter.iso_format_to_unix_time('2017-11-10T09:00:00'), "reading": 0.65 }),
+            ElectricityReading({ "time": TimeConverter.iso_format_to_unix_time('2017-11-10T09:30:00'), "reading": 0.35 }),
+            ElectricityReading({ "time": TimeConverter.iso_format_to_unix_time('2017-11-10T10:00:00'), "reading": 0.5 })
         ])
         self.price_plan_service.electricity_reading_service.retrieve_readings_for = reading_service_mock
 
         spend = self.price_plan_service.get_list_of_spend_against_each_price_plan_for('smart-meter-1001')
-        self.assertEqual(spend[0], { 'X6': 60.24650390344476 })
-        self.assertEqual(spend[1], { 'X2': 120.49300780688952 })
-        self.assertEqual(spend[2], { 'X1': 602.4650390344476 })
+        self.assertEqual(spend[0], { 'X6': 0.5 })
+        self.assertEqual(spend[1], { 'X2': 1 })
+        self.assertEqual(spend[2], { 'X1': 5 })

--- a/test/service/test_PricePlanService.py
+++ b/test/service/test_PricePlanService.py
@@ -7,7 +7,7 @@ from repository.electricity_reading_repository import ElectricityReadingReposito
 from repository.price_plan_repository import price_plan_repository
 from service.price_plan_service import PricePlanService
 
-class TestElectricityReadingService(TestCase):
+class TestPricePlanService(TestCase):
     electricity_reading_repository = ElectricityReadingRepository()
     price_plan_service = PricePlanService(electricity_reading_repository)
 

--- a/test/service/test_TimeConverter.py
+++ b/test/service/test_TimeConverter.py
@@ -1,16 +1,17 @@
 from unittest import TestCase
 
-from service.time_converter import TimeConverter
+from service.time_converter import iso_format_to_unix_time, time_elapsed_in_hours
+
 
 class TestTimeConverter(TestCase):
 
     def test_iso_format_to_unix_time(self):
-        self.assertEqual(TimeConverter.iso_format_to_unix_time('1970-01-01T00:00:00'), 0)
-        self.assertEqual(TimeConverter.iso_format_to_unix_time('1970-01-01T01:00:01'), 3601)
-        self.assertEqual(TimeConverter.iso_format_to_unix_time('2020-02-29T23:12:41'), 1583017961)
+        self.assertEqual(iso_format_to_unix_time('1970-01-01T00:00:00'), 0)
+        self.assertEqual(iso_format_to_unix_time('1970-01-01T01:00:01'), 3601)
+        self.assertEqual(iso_format_to_unix_time('2020-02-29T23:12:41'), 1583017961)
 
     def test_calculate_elapsed_time_in_hours_from_two_unix_timestamps(self):
-        earlier = TimeConverter.iso_format_to_unix_time('2018-05-24T11:30:00')
-        later = TimeConverter.iso_format_to_unix_time('2018-05-24T12:00:00')
+        earlier = iso_format_to_unix_time('2018-05-24T11:30:00')
+        later = iso_format_to_unix_time('2018-05-24T12:00:00')
 
-        self.assertEqual(TimeConverter.time_elapsed_in_hours(earlier, later), 0.5)
+        self.assertEqual(time_elapsed_in_hours(earlier, later), 0.5)

--- a/test/service/test_TimeConverter.py
+++ b/test/service/test_TimeConverter.py
@@ -1,14 +1,16 @@
-from datetime import datetime
 from unittest import TestCase
 
 from service.time_converter import TimeConverter
 
 class TestTimeConverter(TestCase):
+
+    def test_iso_format_to_unix_time(self):
+        self.assertEqual(TimeConverter.iso_format_to_unix_time('1970-01-01T00:00:00'), 0)
+        self.assertEqual(TimeConverter.iso_format_to_unix_time('1970-01-01T01:00:01'), 3601)
+        self.assertEqual(TimeConverter.iso_format_to_unix_time('2020-02-29T23:12:41'), 1583017961)
+
     def test_calculate_elapsed_time_in_hours_from_two_unix_timestamps(self):
-        earlier = self.unix_time_of(datetime.fromisoformat('2018-05-24T11:30:00'))
-        later = self.unix_time_of(datetime.fromisoformat('2018-05-24T12:00:00'))
+        earlier = TimeConverter.iso_format_to_unix_time('2018-05-24T11:30:00')
+        later = TimeConverter.iso_format_to_unix_time('2018-05-24T12:00:00')
 
         self.assertEqual(TimeConverter.time_elapsed_in_hours(earlier, later), 0.5)
-
-    def unix_time_of(self, dt):
-        return (dt - datetime(1970,1,1)).total_seconds()


### PR DESCRIPTION
Hi all,

I added a central way of converting iso date strings to unix timestamps. With this we can use iso timestamps in the tests and therefor make the tests easier to understand.

Additionally, I changed the test values of some tests to make it easier to recalculate the expected results.

Also the smart meter ids of the test users documented in the `README` ('smart-meter-0' etc.) are now used in the implementation.

Last but not least I changed some names which were copy & paste or to vague.

Hope this helps to make the code a bit cleaner and easier to understand, so we don't have to waste precious time in the interviews.

Cheers
Nina

